### PR TITLE
Opencv min version update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,22 +5,25 @@ project(RGBD_RTK)
 message(STATUS "Project source directory: " ${PROJECT_SOURCE_DIR})
 message(STATUS "Build directory: " ${PROJECT_BINARY_DIR})
 
-find_package(OpenCV 2.4 REQUIRED)
+find_package(OpenCV REQUIRED)
 if(OpenCV_FOUND)
-	message(STATUS "OpenCV found")
+	message(STATUS "OpenCV version: " ${OpenCV_VERSION})
+	if(OpenCV_VERSION VERSION_LESS "3.0.0")
+  		message(FATAL_ERROR "ERROR: OpenCV version >= 3.0 required")
+	endif()
 else()
 	message(FATAL_ERROR "Error: OpenCV was not found in your system")
 endif()
 
 find_package(PCL 1.8 REQUIRED)
 if(PCL_FOUND)
-	message(STATUS "PCL found")
+	message(STATUS "PCL version: " ${PCL_VERSION})
 else()
 	message(FATAL_ERROR "Error: PCL was not found in your system")
 endif()
 
 # Force OpenCVPCL versions if ROS is installed
-# set(OpenCV_INCLUDE_DIRS "/home/bruno/Lib/opencv-2.4.13/local/include")
+#set(OpenCV_INCLUDE_DIRS "/home/bruno/Lib/opencv-3.3.1/local/include")
 
 include_directories(${OpenCV_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS} common io tracking motion_estimation
                     visualization)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Inside of the build directory, run the cmake command so that it will create the 
 cmake ..
 ```
 
-Then, compile the rgbt_rtk by using the make command. The -j4 is optional but it is recommended. With it your code will me compiled in 4 parallel tasks.
+Then, compile the rgbt_rtk by using the make command. The -j4 is optional but it is recommended. With it your code will be compiled in 4 parallel tasks.
 
 ```bash
 make -j4
@@ -56,9 +56,15 @@ make -j4
 sudo make install
 ```
 
-<!--
-### License
+License
+------------
+
+This code is distributed under the terms of the [BSD License](https://github.com/natalnet-lpr/rgbd_rtk/blob/master/LICENSE).
 
 
-### Authors
--->
+Authors
+------------
+
+Natalnet Laboratory for Perceptual Robotics, Federal University of Rio Grande do Norte, Brazil.
+
+Contact: bruno.silva AT ect.ufrn.br

--- a/README.md
+++ b/README.md
@@ -1,31 +1,64 @@
-============================
-Natalnet/LPR RGB-D Reconstruction Toolkit
-============================
+# Natalnet/LPR RGB-D Reconstruction Toolkit
 
-------------
+
 Introduction
 ------------
 
 A set of utility code built by the Natalnet/LPR group for 3D reconstruction
 applications using RGB-D (e.g. Microsoft Kinect) cameras.
 
-------------
 Requirements
 ------------
 
-- OpenCV: www.opencv.org
-- PCL: www.pointclouds.org
+- OpenCV: www.opencv.org  (version >= 3.X)
+- PCL: www.pointclouds.org (version 1.8)
+
+It is recommended to install both dependencies from source. The following two links will redirect you to their official tutorials to do so.
+
+> [Install OpenCV on Linux](https://docs.opencv.org/3.3.1/d7/d9f/tutorial_linux_install.html#linux-installation])
+
+> [Compiling PCL from source on Linux](http://pointclouds.org/documentation/tutorials/compiling_pcl_posix.php)
+
+Building
+------------
+
+First, get the newest version of this repository by using the follwing command on your working directory.
+
+```bash
+cd /my_working _directory 
+```
+
+```bash
+git clone https://github.com/natalnet-lpr/rgbd_rtk.git
+```
+
+Create a directory called build, and change directory to it.
+
+```bash
+mkdir build
+``` 
+```bash
+cd build/
+```
+
+Inside of the build directory, run the cmake command so that it will create the necessary makefiles.
+```bash
+cmake ..
+```
+
+Then, compile the rgbt_rtk by using the make command. The -j4 is optional but it is recommended. With it your code will me compiled in 4 parallel tasks.
+
+```bash
+make -j4
+```
+
+```bash
+sudo make install
+```
 
 <!--
---------
-Building
---------
---
+### License
 
--------
-License
--------
 
--------
-Authors
-------->
+### Authors
+-->

--- a/io/rgbd_loader.cpp
+++ b/io/rgbd_loader.cpp
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <limits>
 #include <opencv2/core.hpp>
 #include <opencv2/highgui.hpp>
 

--- a/io/sequence_loader.cpp
+++ b/io/sequence_loader.cpp
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <limits>
 #include <opencv2/core.hpp>
 #include <opencv2/highgui.hpp>
 

--- a/tracking/klt_tracker.cpp
+++ b/tracking/klt_tracker.cpp
@@ -51,7 +51,7 @@ void KLTTracker::detect_keypoints()
 {
 	//Detect Shi-Tomasi keypoints and add them to a temporary buffer.
 	//The buffer is erased at the end of add_keypoints()
-	goodFeaturesToTrack(curr_frame_gray_, added_pts_, max_pts_, 0.01, 10, Mat(), 3, 0, 0.04);
+	goodFeaturesToTrack(curr_frame_gray_, added_pts_, max_pts_, 0.01, 10.0, Mat(), 3, false, 0.04);
 	#ifdef DEBUG
 	printf("detecting keypoints...\n");
 	printf("\tdetected pts.: %lu\n", added_pts_.size());


### PR DESCRIPTION
RGB-D RTK now requires OpenCV version >= 3.X.

The changes were tested under two different Ubuntu 14.04 machines (using OpenCV 3.1.0 and 3.3.1) and also under MacOS Sierra (using a OpenCV snapshot from git).