### PR TITLE
Fixed includes to increase compatibility.

### DIFF
--- a/applications/monocular_calibration.cpp
+++ b/applications/monocular_calibration.cpp
@@ -27,9 +27,9 @@
 #include <cstdio>
 #include <ctime>
 #include <vector>
-#include <opencv2/core.hpp>
-#include <opencv2/highgui.hpp>
-#include <opencv2/calib3d.hpp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
 using namespace cv;

--- a/applications/monocular_image_grabber.cpp
+++ b/applications/monocular_image_grabber.cpp
@@ -29,8 +29,8 @@
 #include <fstream>
 #include <iomanip>
 #include <sys/time.h>
-#include <opencv2/core.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
 using namespace std;

--- a/applications/rgbd_loader_test.cpp
+++ b/applications/rgbd_loader_test.cpp
@@ -26,8 +26,8 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <opencv2/core.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 #include <rgbd_loader.h>
 

--- a/applications/sequence_loader_test.cpp
+++ b/applications/sequence_loader_test.cpp
@@ -26,8 +26,8 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <opencv2/core.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 #include <sequence_loader.h>
 

--- a/common/geometry.h
+++ b/common/geometry.h
@@ -27,8 +27,9 @@
 #ifndef INCLUDE_GEOMETRY_H_
 #define INCLUDE_GEOMETRY_H_
 
-#include <opencv2/core.hpp>
+#include <opencv2/core/core.hpp>
 #include <pcl/point_cloud.h>
+ 
 #include <common_types.h>
 
 //Utility function: returns true if the 3D point does not contain NaN values

--- a/io/rgbd_loader.cpp
+++ b/io/rgbd_loader.cpp
@@ -28,8 +28,8 @@
 #include <cstdlib>
 #include <fstream>
 #include <limits>
-#include <opencv2/core.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 #include "rgbd_loader.h"
 

--- a/io/rgbd_loader.h
+++ b/io/rgbd_loader.h
@@ -28,7 +28,7 @@
 #define INCLUDE_RGBD_LOADER_H_
 
 #include <vector>
-#include <opencv2/core.hpp>
+#include <opencv2/core/core.hpp>
 
 class RGBDLoader
 {

--- a/io/sequence_loader.cpp
+++ b/io/sequence_loader.cpp
@@ -28,8 +28,8 @@
 #include <cstdlib>
 #include <fstream>
 #include <limits>
-#include <opencv2/core.hpp>
-#include <opencv2/highgui.hpp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 #include "sequence_loader.h"
 

--- a/io/sequence_loader.h
+++ b/io/sequence_loader.h
@@ -28,7 +28,7 @@
 #define INCLUDE_SEQUENCE_LOADER_H_
 
 #include <vector>
-#include <opencv2/core.hpp>
+#include <opencv2/core/core.hpp>
 
 class SequenceLoader
 {

--- a/motion_estimation/motion_estimator_ransac.cpp
+++ b/motion_estimation/motion_estimator_ransac.cpp
@@ -27,11 +27,10 @@
 #include <Eigen/Geometry>
 #include <pcl/sample_consensus/ransac.h>
 #include <pcl/sample_consensus/sac_model_registration.h>
+ #include <pcl/common/transforms.h>
 
 #include <geometry.h>
 #include <motion_estimator_ransac.h>
-
-#include <pcl/common/transforms.h>
 
 using namespace std;
 

--- a/tracking/klt_tracker.h
+++ b/tracking/klt_tracker.h
@@ -29,7 +29,7 @@
 
 #include <vector>
 #include <fstream>
-#include <opencv2/core.hpp>
+#include <opencv2/core/core.hpp>
 
 #include <common_types.h>
 


### PR DESCRIPTION
Some versions of opencv do not install e.g. "opencv2/core.hpp",
and install only "opencv2/core/core.hpp".