### PR TITLE
Fixed the use of EventLogger singleton class.

### DIFF
--- a/common/event_logger.cpp
+++ b/common/event_logger.cpp
@@ -32,6 +32,8 @@
 
 using namespace std;
 
+EventLogger& logger = EventLogger::getInstance();
+
 void EventLogger::initialize()
 {
 	log_file_ = fopen(EventLogger::file_name_.c_str(), "w");

--- a/common/event_logger.h
+++ b/common/event_logger.h
@@ -167,4 +167,6 @@ public:
 	void printError(const char* module_class, const char* msg);
 };
 
+extern EventLogger& logger;
+
 #endif /* INCLUDE_EVENT_LOGGER_H_ */

--- a/io/config_loader.cpp
+++ b/io/config_loader.cpp
@@ -1,7 +1,7 @@
 /* 
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2016-2019, Natalnet Laboratory for Perceptual Robotics
+ *  Copyright (c) 2016-2020, Natalnet Laboratory for Perceptual Robotics
  *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without modification, are permitted provided
  *  that the following conditions are met:
@@ -33,9 +33,9 @@
 #include <fstream>
 
 #include <opencv2/opencv.hpp>
+
 #include <config_loader.h>
 #include <event_logger.h>
-#include <rgbd_loader.h>
 
 using namespace std;
 using namespace cv;

--- a/io/kitti_stereo_loader.cpp
+++ b/io/kitti_stereo_loader.cpp
@@ -1,7 +1,7 @@
 /* 
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2016-2019, Natalnet Laboratory for Perceptual Robotics
+ *  Copyright (c) 2016-2020, Natalnet Laboratory for Perceptual Robotics
  *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without modification, are permitted provided
  *  that the following conditions are met:
@@ -38,9 +38,8 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
-#include "kitti_stereo_loader.h"
 #include <event_logger.h>
-#include <rgbd_loader.h>
+#include <kitti_stereo_loader.h>
 
 using namespace cv;
 using namespace std;

--- a/io/kitti_velodyne_loader.cpp
+++ b/io/kitti_velodyne_loader.cpp
@@ -1,7 +1,7 @@
 /* 
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2016-2019, Natalnet Laboratory for Perceptual Robotics
+ *  Copyright (c) 2016-2020, Natalnet Laboratory for Perceptual Robotics
  *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without modification, are permitted provided
  *  that the following conditions are met:
@@ -38,8 +38,7 @@
 #include <opencv2/core/core.hpp>
 
 #include <event_logger.h>
-#include <rgbd_loader.h>
-#include "kitti_velodyne_loader.h"
+#include <kitti_velodyne_loader.h>
 
 using namespace std;
 using namespace cv;

--- a/io/rgbd_loader.cpp
+++ b/io/rgbd_loader.cpp
@@ -37,8 +37,6 @@
 using namespace std;
 using namespace cv;
 
-EventLogger& logger = EventLogger::getInstance();
-
 void RGBDLoader::processFile(const string& file_name)
 {
 	ifstream index_file(file_name.c_str());

--- a/io/rgbd_loader.h
+++ b/io/rgbd_loader.h
@@ -1,7 +1,7 @@
 /* 
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2016, Natalnet Laboratory for Perceptual Robotics
+ *  Copyright (c) 2016-2020, Natalnet Laboratory for Perceptual Robotics
  *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without modification, are permitted provided
  *  that the following conditions are met:
@@ -30,8 +30,6 @@
 #include <vector>
 #include <opencv2/core/core.hpp>
 #include <event_logger.h>
-
-extern EventLogger& logger;
 
 class RGBDLoader
 {

--- a/io/sequence_loader.cpp
+++ b/io/sequence_loader.cpp
@@ -31,9 +31,8 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
-#include "sequence_loader.h"
+#include <sequence_loader.h>
 #include <event_logger.h>
-#include <rgbd_loader.h>
 
 using namespace std;
 using namespace cv;

--- a/motion_estimation/motion_estimator_icp.cpp
+++ b/motion_estimation/motion_estimator_icp.cpp
@@ -1,7 +1,7 @@
 /* 
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2016-2018, Natalnet Laboratory for Perceptual Robotics
+ *  Copyright (c) 2016-2020, Natalnet Laboratory for Perceptual Robotics
  *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without modification, are permitted provided
  *  that the following conditions are met:
@@ -30,7 +30,6 @@
 
 #include <motion_estimator_icp.h>
 #include <event_logger.h>
-#include <motion_estimator_ransac.h>
 
 using namespace std;
 

--- a/motion_estimation/motion_estimator_ransac.cpp
+++ b/motion_estimation/motion_estimator_ransac.cpp
@@ -1,7 +1,7 @@
 /* 
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2016-2019, Natalnet Laboratory for Perceptual Robotics
+ *  Copyright (c) 2016-2020, Natalnet Laboratory for Perceptual Robotics
  *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without modification, are permitted provided
  *  that the following conditions are met:
@@ -33,12 +33,10 @@
 #include <pcl/common/transforms.h>
 
 #include <geometry.h>
-#include <event_logger.h>
 #include <motion_estimator_ransac.h>
+#include <event_logger.h>
 
 using namespace std;
-
-EventLogger& logger = EventLogger::getInstance();
 
 void MotionEstimatorRANSAC::setDataFromCorrespondences(const std::vector<cv::Point2f>& tgt_points, const pcl::PointCloud<PointT>::Ptr& tgt_dense_cloud,
 		                                               const std::vector<cv::Point2f>& src_points, const pcl::PointCloud<PointT>::Ptr& src_dense_cloud)

--- a/motion_estimation/motion_estimator_ransac.h
+++ b/motion_estimation/motion_estimator_ransac.h
@@ -34,9 +34,6 @@
 #include <common_types.h>
 
 #include <pcl/correspondence.h>
-#include <event_logger.h>
-
-extern EventLogger& logger;
 
 class MotionEstimatorRANSAC
 {

--- a/tracking/feature_tracker.cpp
+++ b/tracking/feature_tracker.cpp
@@ -1,11 +1,7 @@
 /* 
  *  Software License Agreement (BSD License)
  *
-<<<<<<< HEAD
- *  Copyright (c) 2016-2019, Natalnet Laboratory for Perceptual Robotics
-=======
- *  Copyright (c) 2016-2018, Natalnet Laboratory for Perceptual Robotics
->>>>>>> feature-quadtree-tracker
+ *  Copyright (c) 2016-2020, Natalnet Laboratory for Perceptual Robotics
  *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without modification, are permitted provided
  *  that the following conditions are met:
@@ -34,11 +30,10 @@
 #include <cstdio>
 #include <string>
 
+#include <event_logger.h>
 #include <feature_tracker.h>
 
 using namespace std;
-
-EventLogger& logger = EventLogger::getInstance();
 
 /* #####################################################
  * #####                                           #####

--- a/tracking/feature_tracker.h
+++ b/tracking/feature_tracker.h
@@ -1,11 +1,7 @@
 /* 
  *  Software License Agreement (BSD License)
  *
-<<<<<<< HEAD
- *  Copyright (c) 2016-2019, Natalnet Laboratory for Perceptual Robotics
-=======
- *  Copyright (c) 2016-2018, Natalnet Laboratory for Perceptual Robotics
->>>>>>> feature-quadtree-tracker
+ *  Copyright (c) 2016-2020, Natalnet Laboratory for Perceptual Robotics
  *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without modification, are permitted provided
  *  that the following conditions are met:
@@ -40,8 +36,6 @@
 
 #include <common_types.h>
 #include <event_logger.h>
-
-extern EventLogger& logger;
 
 /*
  * Abstract Base Class for Feature Trackers.

--- a/tracking/klt_tracker.cpp
+++ b/tracking/klt_tracker.cpp
@@ -37,6 +37,7 @@
 #include <opencv2/features2d/features2d.hpp>
 #include <opencv2/video/video.hpp>
 
+#include <event_logger.h>
 #include <klt_tracker.h>
 
 using namespace std;

--- a/tracking/kltatcw_tracker.cpp
+++ b/tracking/kltatcw_tracker.cpp
@@ -39,6 +39,7 @@
 #include <opencv2/features2d/features2d.hpp>
 #include <opencv2/video/video.hpp>
 
+#include <event_logger.h>
 #include <kltatcw_tracker.h>
 
 using namespace std;

--- a/tracking/kltqt_tracker.cpp
+++ b/tracking/kltqt_tracker.cpp
@@ -39,6 +39,7 @@
 #include <opencv2/features2d/features2d.hpp>
 #include <opencv2/video/video.hpp>
 
+#include <event_logger.h>
 #include <kltqt_tracker.h>
 
 using namespace std;

--- a/tracking/klttcw_tracker.cpp
+++ b/tracking/klttcw_tracker.cpp
@@ -39,6 +39,7 @@
 #include <opencv2/features2d/features2d.hpp>
 #include <opencv2/video/video.hpp>
 
+#include <event_logger.h>
 #include <klttcw_tracker.h>
 
 using namespace std;

--- a/tracking/klttw_tracker.cpp
+++ b/tracking/klttw_tracker.cpp
@@ -38,6 +38,7 @@
 #include <opencv2/features2d/features2d.hpp>
 #include <opencv2/video/video.hpp>
 
+#include <event_logger.h>
 #include <klttw_tracker.h>
 
 using namespace std;


### PR DESCRIPTION
Now the extern is declared in event_logger.h and
the variable is defined only once in event_logger.cpp.
To log messages with EventLogger class, the code
must include event_logger.h.