### PR TITLE
New Parameter pose_format in detectMarker

### DIFF
--- a/applications/marker_finder_test.cpp
+++ b/applications/marker_finder_test.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
 	ReconstructionVisualizer visualizer;
 	Mat frame, depth;
 	float marker_size, aruco_max_distance;
-	string camera_calibration_file, aruco_dic, index_file;
+	string camera_calibration_file, aruco_dic, index_file, poses_format;
 
 	if(argc != 2)
 	{
@@ -70,6 +70,8 @@ int main(int argc, char **argv)
 	param_loader.checkAndGetString("camera_calibration_file", camera_calibration_file);
 	param_loader.checkAndGetString("index_file", index_file);
 	param_loader.checkAndGetString("aruco_dic", aruco_dic);
+    param_loader.checkAndGetString("poses_format", poses_format);
+
 	MarkerFinder marker_finder;
 	marker_finder.markerParam(camera_calibration_file, marker_size, aruco_dic);
 	
@@ -85,7 +87,7 @@ int main(int argc, char **argv)
 		vo.computeCameraPose(frame, depth);
 		
 		//Find ARUCO markers and compute their poses
-		marker_finder.detectMarkers(frame, vo.pose_, aruco_max_distance);
+		marker_finder.detectMarkers(frame, vo.pose_, aruco_max_distance, poses_format);
         for (size_t i = 0; i < marker_finder.markers_.size(); i++)
 		{
             marker_finder.markers_[i].draw(frame, Scalar(0,0,255), 1);

--- a/slam/marker_finder.cpp
+++ b/slam/marker_finder.cpp
@@ -165,12 +165,13 @@ void MarkerFinder::markerParam(const string& params, const float& size, const st
 	camera_params_.readFromXMLFile(params);
 	marker_size_ = size;
 }
-void MarkerFinder::detectMarkers(const cv::Mat& img,const Eigen::Affine3f& cam_pose,const float& aruco_max_distance)
+void MarkerFinder::detectMarkers(const cv::Mat& img, const Eigen::Affine3f& cam_pose, const float& aruco_max_distance, const string& poses_format)
 {
 	markers_.clear();
 	marker_detector_.detect(img, markers_, camera_params_, marker_size_);
 	
-	setMarkerPosesLocal(aruco_max_distance);
-	setMarkerPosesGlobal(cam_pose, aruco_max_distance);
-	setMarkerPointPosesGlobal(cam_pose, aruco_max_distance);
+	if(poses_format == "local") setMarkerPosesLocal(aruco_max_distance);
+	else if (poses_format == "global") setMarkerPosesGlobal(cam_pose, aruco_max_distance);
+	else if (poses_format == "point_global") setMarkerPointPosesGlobal(cam_pose, aruco_max_distance);
+	else setMarkerPosesGlobal(cam_pose, aruco_max_distance);
 }

--- a/slam/marker_finder.h
+++ b/slam/marker_finder.h
@@ -101,9 +101,10 @@ public:
 	void markerParam(const string& params, const float& size, const string& aruco_dic);
 	/**
 	 * Detect ARUCO markers. Also sets the poses of all detected markers in the local and global ref. frames
-	 * @param rgb image, camera pose, and  aruco max distance
+	 * @param rgb image, camera pose, aruco max distance and poses_format(poses_local, poses_global, point_poses_global)
+	 * Uses poses_global as default
 	 */	
-	void detectMarkers(const cv::Mat& img,const Eigen::Affine3f& cam_pose,const float& aruco_max_distance);
-};
+	void detectMarkers(const cv::Mat& img, const Eigen::Affine3f& cam_pose, const float& aruco_max_distance, const string& poses_format);
 
+};
 #endif /* INCLUDE_MARKER_FINDER_H_ */


### PR DESCRIPTION
. Now you have to select which kind of

format the aruco pose will return, there are three ways: poses_local, poses_global
and poses_point_global, it uses poses_global as default.

#66 solved 