### PR TITLE
new parameter aruco distance

### DIFF
--- a/applications/marker_finder_test.cpp
+++ b/applications/marker_finder_test.cpp
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 		vo.computeCameraPose(frame, depth);
 		
 		//Find ARUCO markers and compute their poses
-		marker_finder.detectMarkers(frame, vo.pose_, aruco_max_distance, poses_format);
+		marker_finder.detectMarkers(frame, vo.pose_, aruco_max_distance, 0.0, poses_format);
         for (size_t i = 0; i < marker_finder.markers_.size(); i++)
 		{
             marker_finder.markers_[i].draw(frame, Scalar(0,0,255), 1);

--- a/slam/marker_finder.cpp
+++ b/slam/marker_finder.cpp
@@ -37,7 +37,7 @@ using namespace std;
 using namespace cv;
 using namespace aruco;
 
-void MarkerFinder::setMarkerPosesLocal(float aruco_max_distance)
+void MarkerFinder::setMarkerPosesLocal(const float& aruco_max_distance)
 {	
 	double x=0,y=0,z=0;
 	marker_poses_local_.clear();
@@ -113,7 +113,7 @@ void MarkerFinder::setMarkerPosesGlobal(const Eigen::Affine3f& cam_pose, const f
 		}
 	}
 }
-void MarkerFinder::setMarkerPointPosesGlobal(Eigen::Affine3f cam_pose, float aruco_max_distance)
+void MarkerFinder::setMarkerPointPosesGlobal(const Eigen::Affine3f& cam_pose, const float& aruco_max_distance, const float& aruco_close_distance)
 {/* This function save the marker pose where the robot need to go.
  It's the same aruco pose but with a value added in order to the robot always find a place inside of the map
  In Some situations the aruco marker can be detected outside of the map, since it is oftenly
@@ -129,7 +129,7 @@ void MarkerFinder::setMarkerPointPosesGlobal(Eigen::Affine3f cam_pose, float aru
 		double x=0,y=0,z=0;
 		F(0,0) = 0.0;
 		F(1,0) = 0.0;
-		F(2,0) = 0.5;
+		F(2,0) = aruco_close_distance;
 		F(3,0) = 1.0;
 
 		Rodrigues(markers_[i].Rvec, R);
@@ -165,13 +165,13 @@ void MarkerFinder::markerParam(const string& params, const float& size, const st
 	camera_params_.readFromXMLFile(params);
 	marker_size_ = size;
 }
-void MarkerFinder::detectMarkers(const cv::Mat& img, const Eigen::Affine3f& cam_pose, const float& aruco_max_distance, const string& poses_format)
+void MarkerFinder::detectMarkers(const cv::Mat& img, const Eigen::Affine3f& cam_pose, const float& aruco_max_distance, const float& aruco_close_distance, const string& poses_format)
 {
 	markers_.clear();
 	marker_detector_.detect(img, markers_, camera_params_, marker_size_);
 	
 	if(poses_format == "local") setMarkerPosesLocal(aruco_max_distance);
 	else if (poses_format == "global") setMarkerPosesGlobal(cam_pose, aruco_max_distance);
-	else if (poses_format == "point_global") setMarkerPointPosesGlobal(cam_pose, aruco_max_distance);
+	else if (poses_format == "point_global") setMarkerPointPosesGlobal(cam_pose, aruco_max_distance, aruco_close_distance);
 	else setMarkerPosesGlobal(cam_pose, aruco_max_distance);
 }

--- a/slam/marker_finder.h
+++ b/slam/marker_finder.h
@@ -59,7 +59,7 @@ protected:
 	 * Set the pose of all detected markers w.r.t. the local/camera ref. frame
 	 * @param minimum distance(camera to marker) to aruco be considered valid
 	 */	
-	void setMarkerPosesLocal(float aruco_max_distance);
+	void setMarkerPosesLocal(const float& aruco_max_distance);
 	
 	/**
 	 * Set the pose of all detected markers w.r.t. the global ref. frame
@@ -71,7 +71,7 @@ protected:
 	 * Set the pose of all detected markers plus a distance in the global ref. frame
 	 * @param camera pose as Affine3f and minimum distance to aruco marker be considered valid
 	 */
-	void setMarkerPointPosesGlobal(Eigen::Affine3f cam_pose, float aruco_max_distance);
+	void setMarkerPointPosesGlobal(const Eigen::Affine3f& cam_pose, const float& aruco_max_distance, const float& aruco_close_distance);
 
 public:
 	
@@ -104,7 +104,7 @@ public:
 	 * @param rgb image, camera pose, aruco max distance and poses_format(poses_local, poses_global, point_poses_global)
 	 * Uses poses_global as default
 	 */	
-	void detectMarkers(const cv::Mat& img, const Eigen::Affine3f& cam_pose, const float& aruco_max_distance, const string& poses_format);
+	void detectMarkers(const cv::Mat& img, const Eigen::Affine3f& cam_pose, const float& aruco_max_distance, const float& aruco_close_distance, const string& poses_format);
 
 };
 #endif /* INCLUDE_MARKER_FINDER_H_ */


### PR DESCRIPTION
This new parameter is an offset for the aruco marker found, it is a distance in meter right at the front of the marker that will be the "new pose" of the aruco marker.

This helps in situations where the marker is found but the pose is not in a valid position, as behind a wall.