### PR TITLE
Feature save pose info

### DIFF
--- a/applications/optical_flow_visual_odometry_test.cpp
+++ b/applications/optical_flow_visual_odometry_test.cpp
@@ -55,7 +55,8 @@ int main(int argc, char **argv)
 	
 	RGBDLoader loader;
 	Intrinsics intr(0);
-	OpticalFlowVisualOdometry vo(intr);
+	OpticalFlowVisualOdometry vo(intr, Eigen::Affine3f::Identity(), true);
+	//OpticalFlowVisualOdometry vo(intr);
 	ReconstructionVisualizer visualizer;
 	string index_file;
 	Mat frame, depth;
@@ -66,7 +67,7 @@ int main(int argc, char **argv)
 		exit(0);
 	}
 	ConfigLoader param_loader(argv[1]);
-	param_loader.checkAndGetString("index_file",index_file);
+	param_loader.checkAndGetString("index_file", index_file);
 	loader.processFile(index_file);
 
 	visualizer.addReferenceFrame(vo.pose_, "origin");
@@ -77,8 +78,14 @@ int main(int argc, char **argv)
 		//Load RGB-D image 
 		loader.getNextImage(frame, depth);
 
+		bool save_pose_information = vo.writePoseInfo("Time Stamp");
+		std::cout << "Pose Info " << save_pose_information << std::endl; 
+
 		//Estimate current camera pose
 		bool is_kf = vo.computeCameraPose(frame, depth);
+
+		// Save the pose information
+		//bool save_pose_information = vo.write_pose_info("Time Stamp", vo.pose_);
 
 		//View tracked points
 		for(size_t k = 0; k < vo.tracker_.curr_pts_.size(); k++)

--- a/applications/optical_flow_visual_odometry_test.cpp
+++ b/applications/optical_flow_visual_odometry_test.cpp
@@ -55,8 +55,7 @@ int main(int argc, char **argv)
 	
 	RGBDLoader loader;
 	Intrinsics intr(0);
-	OpticalFlowVisualOdometry vo(intr, Eigen::Affine3f::Identity(), true);
-	//OpticalFlowVisualOdometry vo(intr);
+	OpticalFlowVisualOdometry vo(intr);
 	ReconstructionVisualizer visualizer;
 	string index_file;
 	Mat frame, depth;
@@ -67,7 +66,7 @@ int main(int argc, char **argv)
 		exit(0);
 	}
 	ConfigLoader param_loader(argv[1]);
-	param_loader.checkAndGetString("index_file", index_file);
+	param_loader.checkAndGetString("index_file",index_file);
 	loader.processFile(index_file);
 
 	visualizer.addReferenceFrame(vo.pose_, "origin");
@@ -78,14 +77,8 @@ int main(int argc, char **argv)
 		//Load RGB-D image 
 		loader.getNextImage(frame, depth);
 
-		bool save_pose_information = vo.writePoseInfo("Time Stamp");
-		std::cout << "Pose Info " << save_pose_information << std::endl; 
-
 		//Estimate current camera pose
 		bool is_kf = vo.computeCameraPose(frame, depth);
-
-		// Save the pose information
-		//bool save_pose_information = vo.write_pose_info("Time Stamp", vo.pose_);
 
 		//View tracked points
 		for(size_t k = 0; k < vo.tracker_.curr_pts_.size(); k++)

--- a/applications/optical_flow_visual_odometry_test.cpp
+++ b/applications/optical_flow_visual_odometry_test.cpp
@@ -60,6 +60,8 @@ int main(int argc, char **argv)
 	string index_file;
 	Mat frame, depth;
 
+	std::string rgb_img_time_stamp;
+
 	if(argc != 2)
 	{
 		logger.print(EventLogger::L_INFO, "[optical_flow_visual_odometry_test.cpp] Usage: %s <path/to/config_file.yaml>\n", argv[0]);
@@ -77,8 +79,11 @@ int main(int argc, char **argv)
 		//Load RGB-D image 
 		loader.getNextImage(frame, depth);
 
+		// Get the rgb image time stamp
+		rgb_img_time_stamp = loader.getNextRgbImageTimeStamp();
+
 		//Estimate current camera pose
-		bool is_kf = vo.computeCameraPose(frame, depth);
+		bool is_kf = vo.computeCameraPose(frame, depth, rgb_img_time_stamp);
 
 		//View tracked points
 		for(size_t k = 0; k < vo.tracker_.curr_pts_.size(); k++)

--- a/io/rgbd_loader.cpp
+++ b/io/rgbd_loader.cpp
@@ -64,6 +64,8 @@ void RGBDLoader::processFile(const string& file_name)
                 num_images_++;
                 rgb_img_names_.push_back(rgb_file);
                 depth_img_names_.push_back(depth_file);
+                rgb_time_stamps_.push_back(ts1);
+                depth_time_stamps_.push_back(ts2);
             }
         }
         else
@@ -97,6 +99,36 @@ void RGBDLoader::getNextImage(cv::Mat& rgb_img, cv::Mat& depth_img)
     else
     {
         MLOG_ERROR(EventLogger::M_IO, "@RGBDLoader::getNextImage: All images of the sequence were already loaded.\n");
+        exit(0);
+    }
+}
+
+std::string RGBDLoader::getNextRgbImageTimeStamp()
+{
+    if (curr_rgb_img_time_stamp_ < num_images_)
+    {
+        std::string ts = rgb_time_stamps_[curr_rgb_img_time_stamp_];
+        curr_rgb_img_time_stamp_++;
+        return ts;
+    }
+    else
+    {
+        MLOG_ERROR(EventLogger::M_IO, "@RGBDLoader::getNextRgbImageTimeStamp: All rgb time stamps of the sequence were already loaded.\n");
+        exit(0);
+    }
+}
+
+std::string RGBDLoader::getNextDepthImageTimeStamp()
+{
+    if (curr_depth_img_time_stamp_ < num_images_)
+    {
+        std::string ts = depth_time_stamps_[curr_depth_img_time_stamp_];
+        curr_depth_img_time_stamp_++;
+        return ts;
+    }
+    else
+    {
+        MLOG_ERROR(EventLogger::M_IO, "@RGBDLoader::getNextDepthImageTimeStamp: All depth time stamps of the sequence were already loaded.\n");
         exit(0);
     }
 }

--- a/io/rgbd_loader.h
+++ b/io/rgbd_loader.h
@@ -48,6 +48,12 @@ private:
     // Vector position of the current RGB-D image
     int curr_img_;
 
+    // Vector position of the current RGB image time stamp
+    int curr_rgb_img_time_stamp_;
+
+    // Vector position of the current Depth image time stamp
+    int curr_depth_img_time_stamp_;
+
     // Path of the index file
     std::string path_;
 
@@ -56,6 +62,12 @@ private:
 
     // Depth file names to be loaded
     std::vector<std::string> depth_img_names_;
+
+    // Time stamps of rgb files
+    std::vector<std::string> rgb_time_stamps_;
+
+    // Time stamps of depth files
+    std::vector<std::string> depth_time_stamps_;
 
 public:
     // Number of images of the sequence
@@ -68,6 +80,8 @@ public:
     {
         num_images_ = 0;
         curr_img_ = 0;
+        curr_rgb_img_time_stamp_ = 0;
+        curr_depth_img_time_stamp_ = 0;
     }
 
     /**
@@ -78,6 +92,8 @@ public:
     {
         num_images_ = 0;
         curr_img_ = 0;
+        curr_rgb_img_time_stamp_ = 0;
+        curr_depth_img_time_stamp_ = 0;
         processFile(index_file_name);
     }
     /**
@@ -92,6 +108,14 @@ public:
       * @param rgb @param depth_img
       */
     void getNextImage(cv::Mat &rgb_img, cv::Mat &depth_img);
+    /**
+     * Returns the next RGB image time stamp.
+     */
+    std::string getNextRgbImageTimeStamp();
+    /**
+     * Returns the next depth image time stamp.
+     */
+    std::string getNextDepthImageTimeStamp();  
 };
 
 #endif /* INCLUDE_RGBD_LOADER_H_ */

--- a/visual_odometry/optical_flow_visual_odometry.cpp
+++ b/visual_odometry/optical_flow_visual_odometry.cpp
@@ -37,9 +37,20 @@ using namespace cv;
 
 void OpticalFlowVisualOdometry::writePoseToFile(const std::string& time_stamp)
 {
-    poses_file_ << time_stamp << pose_(0,0) << " " << pose_(0,1) << " " << pose_(0,2) << " " << pose_(0,3) << " "
-	                          << pose_(1,0) << " " << pose_(1,1) << " " << pose_(1,2) << " " << pose_(1,3) << " "
-	                          << pose_(2,0) << " " << pose_(2,1) << " " << pose_(2,2) << " " << pose_(2,3) << "\n"; 
+    Eigen::Matrix3f Rot;
+	Rot(0,0) = pose_(0,0); Rot(0,1) = pose_(0,1); Rot(0,2) = pose_(0,2);
+	Rot(1,0) = pose_(1,0); Rot(1,1) = pose_(1,1); Rot(1,2) = pose_(1,2);
+	Rot(2,0) = pose_(2,0); Rot(2,1) = pose_(2,1); Rot(2,2) = pose_(2,2);
+	
+    Eigen::Quaternionf q(Rot);
+	
+    poses_file_ << time_stamp <<  " "  << pose_(0,3) << " "
+								  	   << pose_(1,3) << " "
+								  	   << pose_(2,3) << " "
+								  	   << q.x() << " "
+								  	   << q.y() << " "
+								  	   << q.z() << " "
+								  	   << q.w() << "\n";
 }
 
 void OpticalFlowVisualOdometry::addKeyFrame(const Mat& rgb)

--- a/visual_odometry/optical_flow_visual_odometry.cpp
+++ b/visual_odometry/optical_flow_visual_odometry.cpp
@@ -28,7 +28,6 @@
  */
 
 #include <algorithm>
-#include <Eigen/Geometry>
 
 #include <geometry.h>
 #include <optical_flow_visual_odometry.h>
@@ -52,21 +51,16 @@ void OpticalFlowVisualOdometry::addKeyFrame(const Mat& rgb)
     keyframes_.insert(pair<size_t, Keyframe>(kf.idx_, kf));
 }
 
-OpticalFlowVisualOdometry::OpticalFlowVisualOdometry(const Eigen::Affine3f& initialPose, const bool& log_stats)
+OpticalFlowVisualOdometry::OpticalFlowVisualOdometry(const Eigen::Affine3f& initialPose)
 {
     frame_idx_ = 0;
     pose_ = initialPose;
 
     prev_dense_cloud_ = pcl::PointCloud<PointT>::Ptr(new pcl::PointCloud<PointT>);
     curr_dense_cloud_ = pcl::PointCloud<PointT>::Ptr(new pcl::PointCloud<PointT>);
-
-    if (log_stats)
-    {
-        initialize_logger("pose_stats.txt");
-    }
 }
 
-OpticalFlowVisualOdometry::OpticalFlowVisualOdometry(const Intrinsics& intr, const Eigen::Affine3f& initialPose, const bool& log_stats)
+OpticalFlowVisualOdometry::OpticalFlowVisualOdometry(const Intrinsics& intr, const Eigen::Affine3f& initialPose)
 {
     frame_idx_ = 0;
     pose_ = initialPose;
@@ -74,28 +68,6 @@ OpticalFlowVisualOdometry::OpticalFlowVisualOdometry(const Intrinsics& intr, con
 
     prev_dense_cloud_ = pcl::PointCloud<PointT>::Ptr(new pcl::PointCloud<PointT>);
     curr_dense_cloud_ = pcl::PointCloud<PointT>::Ptr(new pcl::PointCloud<PointT>);
-
-    if (log_stats)
-    {
-        initialize_logger("pose_stats.txt");
-    }
-}
-
-void OpticalFlowVisualOdometry::initialize_logger(const std::string& pose_file_name)
-{
-    pose_info_.open(pose_file_name.c_str());
-    if (!pose_info_.is_open())
-    {
-        MLOG_ERROR(EventLogger::M_VISUAL_ODOMETRY, "@OpticalFlowVisualOdometry::initialize_logger: \
-			                                        there is a problem with the supplied \
-			                                        file for the pose information.\n");
-		exit(-1);
-    }
-    
-    pose_info_ << "Saving pose information \n"; 
-
-    MLOG_INFO(EventLogger::M_VISUAL_ODOMETRY, "@OpticalFlowVisualOdometry::initialize_logger: saving \
-		                                        pose information to %s\n", pose_file_name.c_str());
 }
 
 bool OpticalFlowVisualOdometry::computeCameraPose(const cv::Mat& rgb, const cv::Mat& depth)
@@ -141,30 +113,4 @@ Keyframe OpticalFlowVisualOdometry::getLastKeyframe()
                                                 last keyframe has id %lu\n", it->first);
     
     return prev(it)->second; // prev from std
-}
-
-bool OpticalFlowVisualOdometry::writePoseInfo(const std::string& time_stamp)
-{   
-    if (pose_info_.is_open())
-    {
-        Eigen::Matrix3f Rot;
-        Rot(0,0) = pose_(0,0); Rot(0,1) = pose_(0,1); Rot(0,2) = pose_(0,2);
-        Rot(1,0) = pose_(1,0); Rot(1,1) = pose_(1,1); Rot(0,2) = pose_(1,2);
-        Rot(2,0) = pose_(2,0); Rot(2,1) = pose_(2,1); Rot(2,2) = pose_(2,2);
-
-        Eigen::Quaternionf q(Rot);
-        /*pose_info_ << time_stamp << " " << pose_(0,3) << " "
-                                            << pose_(1,3) << " "
-                                            << pose_(2,3) << " "
-                                            << q.x() << " "
-                                            << q.y() << " "
-                                            << q.z() << " "
-                                            << q.w() << "\n";*/
-
-        //pose_info_ << "Testando...\n"; 
-        
-        MLOG_DEBUG(EventLogger::M_VISUAL_ODOMETRY, "@OpticalFlowVisualOdometry::write_pose_info: save pose information...\n");
-    }
-
-    return pose_info_.good(); 
 }

--- a/visual_odometry/optical_flow_visual_odometry.h
+++ b/visual_odometry/optical_flow_visual_odometry.h
@@ -41,7 +41,6 @@
 #ifndef INCLUDE_OPTICAL_FLOW_VISUAL_ODOMETRY_H_
 #define INCLUDE_OPTICAL_FLOW_VISUAL_ODOMETRY_H_
 
-#include <fstream>
 #include <Eigen/Geometry>
 #include <map>
 #include <opencv2/core/core.hpp>
@@ -51,7 +50,6 @@
 #include <motion_estimator_ransac.h>
 #include <wide_baseline_tracker.h>
 
-
 class OpticalFlowVisualOdometry
 {
 private:
@@ -60,9 +58,6 @@ private:
 
     // Adds a new keyframe to the internal container of keyframes
     void addKeyFrame(const cv::Mat& rgb);
-
-    // Output file with pose information
-    std::ofstream pose_info_;
 
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -88,20 +83,15 @@ public:
     /**
      * Default constructor
      * @param initialPose start pose of the camera, identity if nothing is passed
-     * @param log_stats boolean for log statistics state default is false
      */
-    OpticalFlowVisualOdometry(const Eigen::Affine3f& initialPose = Eigen::Affine3f::Identity(), 
-                              const bool& log_stats = false);
+    OpticalFlowVisualOdometry(const Eigen::Affine3f& initialPose = Eigen::Affine3f::Identity());
 
     /**
      * Constructor with the matrix of intrinsic parameters
      * @param intr camera parameters
      * @param initialPose start pose of the camera, identity if nothing is passed
-     * @param log_stats boolean for log statistics state default is false
      */
-    OpticalFlowVisualOdometry(const Intrinsics& intr, 
-                              const Eigen::Affine3f& initialPose = Eigen::Affine3f::Identity(), 
-                              const bool& log_stats = false);
+    OpticalFlowVisualOdometry(const Intrinsics& intr, const Eigen::Affine3f& initialPose = Eigen::Affine3f::Identity());
 
     /**
      * Main member function: computes the current camera pose.
@@ -115,18 +105,6 @@ public:
      * @param Keyframe return the last detected keyframe.
      */
     Keyframe getLastKeyframe();
-
-    /**
-     * Sets the output file for pose information.
-     * If not called, the system will not write any information to file.
-     * @param pose_file_name file name
-     */
-    void initialize_logger(const std::string& pose_file_name);
-
-    /**
-     * @param time_stamp time of the processed pose.
-     */
-    bool writePoseInfo(const std::string& time_stamp);
 };
 
 #endif /* INCLUDE_OPTICAL_FLOW_VISUAL_ODOMETRY_H_ */

--- a/visual_odometry/optical_flow_visual_odometry.h
+++ b/visual_odometry/optical_flow_visual_odometry.h
@@ -41,6 +41,7 @@
 #ifndef INCLUDE_OPTICAL_FLOW_VISUAL_ODOMETRY_H_
 #define INCLUDE_OPTICAL_FLOW_VISUAL_ODOMETRY_H_
 
+#include <fstream>
 #include <Eigen/Geometry>
 #include <map>
 #include <opencv2/core/core.hpp>
@@ -50,6 +51,7 @@
 #include <motion_estimator_ransac.h>
 #include <wide_baseline_tracker.h>
 
+
 class OpticalFlowVisualOdometry
 {
 private:
@@ -58,6 +60,9 @@ private:
 
     // Adds a new keyframe to the internal container of keyframes
     void addKeyFrame(const cv::Mat& rgb);
+
+    // Output file with pose information
+    std::ofstream pose_info_;
 
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -83,15 +88,20 @@ public:
     /**
      * Default constructor
      * @param initialPose start pose of the camera, identity if nothing is passed
+     * @param log_stats boolean for log statistics state default is false
      */
-    OpticalFlowVisualOdometry(const Eigen::Affine3f& initialPose = Eigen::Affine3f::Identity());
+    OpticalFlowVisualOdometry(const Eigen::Affine3f& initialPose = Eigen::Affine3f::Identity(), 
+                              const bool& log_stats = false);
 
     /**
      * Constructor with the matrix of intrinsic parameters
      * @param intr camera parameters
      * @param initialPose start pose of the camera, identity if nothing is passed
+     * @param log_stats boolean for log statistics state default is false
      */
-    OpticalFlowVisualOdometry(const Intrinsics& intr, const Eigen::Affine3f& initialPose = Eigen::Affine3f::Identity());
+    OpticalFlowVisualOdometry(const Intrinsics& intr, 
+                              const Eigen::Affine3f& initialPose = Eigen::Affine3f::Identity(), 
+                              const bool& log_stats = false);
 
     /**
      * Main member function: computes the current camera pose.
@@ -105,6 +115,18 @@ public:
      * @param Keyframe return the last detected keyframe.
      */
     Keyframe getLastKeyframe();
+
+    /**
+     * Sets the output file for pose information.
+     * If not called, the system will not write any information to file.
+     * @param pose_file_name file name
+     */
+    void initialize_logger(const std::string& pose_file_name);
+
+    /**
+     * @param time_stamp time of the processed pose.
+     */
+    bool writePoseInfo(const std::string& time_stamp);
 };
 
 #endif /* INCLUDE_OPTICAL_FLOW_VISUAL_ODOMETRY_H_ */

--- a/visual_odometry/optical_flow_visual_odometry.h
+++ b/visual_odometry/optical_flow_visual_odometry.h
@@ -43,8 +43,10 @@
 
 #include <Eigen/Geometry>
 #include <map>
+#include <fstream>
 #include <opencv2/core/core.hpp>
 #include <pcl/point_cloud.h>
+
 
 #include <common_types.h>
 #include <motion_estimator_ransac.h>
@@ -58,6 +60,15 @@ private:
 
     // Adds a new keyframe to the internal container of keyframes
     void addKeyFrame(const cv::Mat& rgb);
+
+    // Output file computed poses
+    std::ofstream poses_file_;
+
+    /**
+     * Writes the last computed visual odometry pose to file.
+     * @param time_stamp, the time that the pose was computed. 
+     */
+    void writePoseToFile(const std::string& time_stamp);
 
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -99,7 +110,18 @@ public:
      * @param rgb image @param depth image
      * @param return a boolean
      */
-    bool computeCameraPose(const cv::Mat& rgb, const cv::Mat& depth);
+
+    ~OpticalFlowVisualOdometry()
+    {
+        poses_file_.close();
+    }
+
+     /**
+     * Main member function: computes the current camera pose
+     * @param rgb and @param depth images.
+     * @param time_stamp, the time that the pose was computed.
+     */ 
+    bool computeCameraPose(const cv::Mat& rgb, const cv::Mat& depth, const std::string& time_stamp = "");
 
     /**
      * @param Keyframe return the last detected keyframe.

--- a/visual_odometry/stereo_optical_flow_visual_odometry.cpp
+++ b/visual_odometry/stereo_optical_flow_visual_odometry.cpp
@@ -35,11 +35,11 @@
 using namespace std;
 using namespace cv;
 
-void StereoOpticalFlowVisualOdometry::writePoseToFile()
+void StereoOpticalFlowVisualOdometry::writePoseToFile(const std::string& time_stamp)
 {
-	poses_file_ << pose_(0,0) << " " << pose_(0,1) << " " << pose_(0,2) << " " << pose_(0,3) << " "
-	            << pose_(1,0) << " " << pose_(1,1) << " " << pose_(1,2) << " " << pose_(1,3) << " "
-	            << pose_(2,0) << " " << pose_(2,1) << " " << pose_(2,2) << " " << pose_(2,3) << "\n"; 
+	poses_file_ << time_stamp << pose_(0,0) << " " << pose_(0,1) << " " << pose_(0,2) << " " << pose_(0,3) << " "
+	            			  << pose_(1,0) << " " << pose_(1,1) << " " << pose_(1,2) << " " << pose_(1,3) << " "
+	            			  << pose_(2,0) << " " << pose_(2,1) << " " << pose_(2,2) << " " << pose_(2,3) << "\n"; 
 }
 
 StereoOpticalFlowVisualOdometry::StereoOpticalFlowVisualOdometry(const Intrinsics& intr,
@@ -61,7 +61,7 @@ motion_estimator_(intr, ransac_thr, 0), cloud_generator_(intr, 1), frame_idx_(0)
 	}
 }
 
-void StereoOpticalFlowVisualOdometry::computeCameraPose(const cv::Mat& left, const cv::Mat& right)
+void StereoOpticalFlowVisualOdometry::computeCameraPose(const cv::Mat& left, const cv::Mat& right, const std::string& time_stamp)
 {
 	Eigen::Affine3f trans = Eigen::Affine3f::Identity();
 
@@ -85,7 +85,7 @@ void StereoOpticalFlowVisualOdometry::computeCameraPose(const cv::Mat& left, con
 	}
 
 	// Write computed odometry pose to file
-	writePoseToFile();
+	writePoseToFile(time_stamp);
 
 	//Let the prev. cloud in the next frame be the current cloud
 	*prev_dense_cloud_ = *curr_dense_cloud_;

--- a/visual_odometry/stereo_optical_flow_visual_odometry.h
+++ b/visual_odometry/stereo_optical_flow_visual_odometry.h
@@ -92,8 +92,9 @@ public:
     /**
      * Main member function: computes the current camera pose
      * @param left left image of stereo camera @param right right image of stereo camera
+     * @param time_stamp, the time that the pose was computed.
      */
-    void computeCameraPose(const cv::Mat &left, const cv::Mat &right);
+    void computeCameraPose(const cv::Mat &left, const cv::Mat &right, const std::string& time_stamp = "");
 
 private:
     // Current frame index
@@ -104,8 +105,9 @@ private:
 
     /**
      * Writes the last computed visual odometry pose to file.
+     * @param time_stamp, the time that the pose was computed.
      */
-    void writePoseToFile();
+    void writePoseToFile(const std::string& time_stamp);
 };
 
 #endif /* INCLUDE_STEREO_OPTICAL_FLOW_VISUAL_ODOMETRY_H_ */


### PR DESCRIPTION
Now in the class `OpticalFlowVisualOdometry` it is possible to save the trajectory of the camera pose during the process of visual odometry.

This is done through a private method called `writePoseToFile` that is executed inside the `computeCameraPose` method. Thus, `computeCameraPose` has a new attribute `time_stamp`, which is then passed to the  `writePoseToFile` method.

The output file is `optical_flow_visual_odometry_poses.txt`.

The standard adopted to register the pose in the file is the same used in the TUM datasets.