### PR TITLE
fixed quadtree memory leak

### DIFF
--- a/applications/kltqt_tracker_test.cpp
+++ b/applications/kltqt_tracker_test.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
 
         if (i == 0) max_density = max_pts / float(frame.cols * frame.rows);
 
-        tracker.tree = new QuadTree(Rect(0, 0, frame.cols, frame.cols), 5, max_density);
+        tracker.tree = make_unique<QuadTree>(Rect(0, 0, frame.cols, frame.cols), 5, max_density);
 
         #if CV_MAJOR_VERSION < 4
 			double el_time = (double) cvGetTickCount();
@@ -122,6 +122,7 @@ int main(int argc, char **argv)
             printf("Exiting.\n");
             break;
         }
+
     }
 
     return 0;

--- a/quadtree/quad_tree.cpp
+++ b/quadtree/quad_tree.cpp
@@ -52,6 +52,28 @@ using namespace cv;
 
 EventLogger &logger = EventLogger::getInstance();
 
+QuadTree::QuadTree() : capacity_(4), divided_(false), allocated_(false), max_density_(0.0)
+{
+}
+
+QuadTree::QuadTree(const cv::Rect &boundary, const int &capacity, const float &max_density)  : divided_(false), allocated_(false)
+{
+    boundary_ = boundary;
+    capacity_ = capacity;
+    max_density_ = max_density;
+    topLeft_ = std::make_unique<QuadTree>();
+    topRight_ = std::make_unique<QuadTree>();
+    botLeft_ = std::make_unique<QuadTree>();
+    botRight_ = std::make_unique<QuadTree>();
+
+    int x = boundary_.x;
+    int y = boundary_.y;
+    int h = boundary_.height;
+    int w = boundary_.width;
+
+    printf("[QuadTree::insert] DEBUG: building node (%i,%i) <-> (%i,%i)\n", x, y, h, w);
+}
+
 void QuadTree::insert(const Point2f &new_point)
 {
     int x = boundary_.x;
@@ -113,25 +135,25 @@ void QuadTree::subdivide()
     logger.print(EventLogger::L_DEBUG,
                  "[QuadTree::insert] DEBUG: creating top left tree (%i,%i) <-> (%i,%i)\n", x, y,
                  x + h / 2, y + w / 2);
-    topLeft_ = new QuadTree(TL_boundary, capacity_, max_density_);
+    topLeft_ =  make_unique<QuadTree>(TL_boundary, capacity_, max_density_);
 
     Rect TR_boundary(x + w / 2, y, h / 2, w / 2);
     logger.print(EventLogger::L_DEBUG,
                  "[QuadTree::insert] DEBUG: creating top right tree (%i,%i) <-> (%i,%i)\n",
                  x + w / 2, y, x + w / 2 + h / 2, y + w / 2);
-    topRight_ = new QuadTree(TR_boundary, capacity_, max_density_);
+    topRight_ = make_unique<QuadTree>(TR_boundary, capacity_, max_density_);
 
     Rect BR_boundary(x + w / 2, y + h / 2, h / 2, w / 2);
     logger.print(EventLogger::L_DEBUG,
                  "[QuadTree::insert] DEBUG: creating bottom right tree (%i,%i) <-> (%i,%i)\n",
                  x + w / 2, y + h / 2, x + w / 2 + h / 2, y + h / 2 + w / 2);
-    botRight_ = new QuadTree(BR_boundary, capacity_, max_density_);
+    botRight_ = make_unique<QuadTree>(BR_boundary, capacity_, max_density_);
 
     Rect BL_boundary(x, y + h / 2, h / 2, w / 2);
     logger.print(EventLogger::L_DEBUG,
-                 "[QuadTree::insert] DEBUG: creating bottom left tree (%i,%i) <-> (%i,%i)\n", x,
+                "[QuadTree::insert] DEBUG: creating bottom left tree (%i,%i) <-> (%i,%i)\n", x,
                  y + h / 2, x + h / 2, y + h / 2 + w / 2);
-    botLeft_ = new QuadTree(BL_boundary, capacity_, max_density_);
+    botLeft_ = make_unique<QuadTree>(BL_boundary, capacity_, max_density_);
 
     divided_ = true;
 }

--- a/quadtree/quad_tree.h
+++ b/quadtree/quad_tree.h
@@ -42,7 +42,7 @@
 #include <opencv2/core/core.hpp>
 #include <vector>
 
-#include <iostream>
+#include <memory>
 
 /*
  * Quad tree data structure to store image keypoints
@@ -55,7 +55,7 @@ public:
     cv::Rect boundary_;
 
     // Maximum number of keypoints in a node of the quadtree
-    int capacity_;
+    std::size_t capacity_;
 
     // Flag used to check if the current node is subdived
     bool divided_;
@@ -67,10 +67,10 @@ public:
     std::vector<cv::Point2f> pts_;
 
     // Quadtree subdivisions
-    QuadTree *topLeft_;
-    QuadTree *topRight_;
-    QuadTree *botLeft_;
-    QuadTree *botRight_;
+    std::unique_ptr<QuadTree> topLeft_;
+    std::unique_ptr<QuadTree> topRight_;
+    std::unique_ptr<QuadTree> botLeft_;
+    std::unique_ptr<QuadTree> botRight_;
 
     // This variable helps in the task of marking the mask.
     // If some region have at least max_density points,
@@ -81,7 +81,7 @@ public:
     /**
      * Default constructor
      */
-    QuadTree() : capacity_(4), divided_(false), allocated_(false), max_density_(0.0) {}
+    QuadTree();
 
     /**
      * Constructor
@@ -89,24 +89,7 @@ public:
      * @param capacity
      * @param max_density default is 0
      */
-    QuadTree(const cv::Rect &boundary, const int &capacity, const float &max_density = 0)
-        : divided_(false), allocated_(false)
-    {
-        boundary_ = boundary;
-        capacity_ = capacity;
-        max_density_ = max_density;
-        topLeft_ = new QuadTree();
-        topRight_ = new QuadTree();
-        botLeft_ = new QuadTree();
-        botRight_ = new QuadTree();
-
-        int x = boundary_.x;
-        int y = boundary_.y;
-        int h = boundary_.height;
-        int w = boundary_.width;
-
-        printf("[QuadTree::insert] DEBUG: building node (%i,%i) <-> (%i,%i)\n", x, y, h, w);
-    }
+    QuadTree(const cv::Rect &boundary, const int &capacity, const float &max_density = 0);
 
     /**
      * Inserts a point in region


### PR DESCRIPTION
Quadtree module was alocating memory indefinetly, to make the fix easier I replaced the raw pointers by unique_ptr, so we doesn't need to worry about create a destructor or free the memory. Order than that, I moved the constructor implementations to the .cpp file.