### PR TITLE
added cache to aruco cmake file

### DIFF
--- a/cmake/Findaruco.cmake
+++ b/cmake/Findaruco.cmake
@@ -20,13 +20,12 @@
 #
 # ===================================================================================
 
-SET(aruco_INCLUDE_DIRS "/usr/local/include"  CACHE PATH "path for aruco include directory")
+SET(aruco_INCLUDE_DIRS "/usr/local/include"  CACHE PATH "Path to aruco include directory")
 
 INCLUDE_DIRECTORIES(${aruco_INCLUDE_DIRS})
 INCLUDE_DIRECTORIES(${aruco_INCLUDE_DIRS}/aruco/)
 
-
-SET(aruco_LIB_DIR "/usr/local/lib" CACHE PATH "path for aruco library directory")
+SET(aruco_LIB_DIR "/usr/local/lib" CACHE PATH "Path to aruco library directory")
 LINK_DIRECTORIES(${aruco_LIB_DIR})
 
 SET(aruco_LIBS opencv_imgproc;opencv_videostab;opencv_ml;opencv_photo;opencv_stitching;opencv_features2d;opencv_calib3d;opencv_objdetect;opencv_shape;opencv_superres;opencv_highgui;opencv_imgcodecs;opencv_dnn;opencv_flann;opencv_core;opencv_video;opencv_videoio;opencv_dpm;opencv_bgsegm;opencv_aruco;opencv_hfs;opencv_optflow;opencv_bioinspired;opencv_xfeatures2d;opencv_phase_unwrapping;opencv_ximgproc;opencv_surface_matching;opencv_plot;opencv_xobjdetect;opencv_saliency;opencv_dnn_objdetect;opencv_datasets;opencv_hdf;opencv_fuzzy;opencv_reg;opencv_img_hash;opencv_tracking;opencv_rgbd;opencv_text;opencv_ccalib;opencv_line_descriptor;opencv_xphoto;opencv_face;opencv_structured_light;opencv_stereo aruco) 

--- a/cmake/Findaruco.cmake
+++ b/cmake/Findaruco.cmake
@@ -19,12 +19,15 @@
 #      - aruco_VERSION_PATCH : Patch version part of VERSION. Example: "0"
 #
 # ===================================================================================
-INCLUDE_DIRECTORIES("/usr/local/include")
-INCLUDE_DIRECTORIES("/usr/local/include/aruco")
-SET(aruco_INCLUDE_DIRS "/usr/local/include")
 
-LINK_DIRECTORIES("/usr/local/lib")
-SET(aruco_LIB_DIR "/usr/local/lib")
+SET(aruco_INCLUDE_DIRS "/usr/local/include"  CACHE PATH "path for aruco include directory")
+
+INCLUDE_DIRECTORIES(${aruco_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(${aruco_INCLUDE_DIRS}/aruco/)
+
+
+SET(aruco_LIB_DIR "/usr/local/lib" CACHE PATH "path for aruco library directory")
+LINK_DIRECTORIES(${aruco_LIB_DIR})
 
 SET(aruco_LIBS opencv_imgproc;opencv_videostab;opencv_ml;opencv_photo;opencv_stitching;opencv_features2d;opencv_calib3d;opencv_objdetect;opencv_shape;opencv_superres;opencv_highgui;opencv_imgcodecs;opencv_dnn;opencv_flann;opencv_core;opencv_video;opencv_videoio;opencv_dpm;opencv_bgsegm;opencv_aruco;opencv_hfs;opencv_optflow;opencv_bioinspired;opencv_xfeatures2d;opencv_phase_unwrapping;opencv_ximgproc;opencv_surface_matching;opencv_plot;opencv_xobjdetect;opencv_saliency;opencv_dnn_objdetect;opencv_datasets;opencv_hdf;opencv_fuzzy;opencv_reg;opencv_img_hash;opencv_tracking;opencv_rgbd;opencv_text;opencv_ccalib;opencv_line_descriptor;opencv_xphoto;opencv_face;opencv_structured_light;opencv_stereo aruco) 
 


### PR DESCRIPTION
One of the worsting things about not compiling using default path (/usr/local) is to manually change the Findaruco.cmake file, so I'm proposing a change to make this file accept cache arguments.